### PR TITLE
Turns the gitea HTTP service into a load-balancing service

### DIFF
--- a/templates/gitea-http.yaml
+++ b/templates/gitea-http.yaml
@@ -14,9 +14,6 @@ spec:
     port: 3000
     protocol: TCP
     targetPort: 3000
-  clusterIP: None
-  clusterIPs:
-  - None
   externalName: {{ .Hostname }}
   selector:
     app: {{ .ApplicationName }}


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets or a short description of what motivated you to do it. -->

See https://github.com/plotly/gitea-operator/commit/d9c58c93c7cb593b9f7366ea9aff5ed727703ecc#r74068113

Closes https://github.com/plotly/dek-deployment/issues/736

## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

This PR reverts the changes that made the gitea HTTP service a headless service!

## Why
<!-- Add a short answer for: Why it was done? (E.g The feature X was deprecated.) -->

Otherwise it breaks networking in `k3d` and possibly other K8S env!

## How
<!-- Add a short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) -->

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->

cc @namgk @x3rus 